### PR TITLE
fix: rename --trace-dir to --out-dir for CLI consistency

### DIFF
--- a/tooling/nargo_cli/build.rs
+++ b/tooling/nargo_cli/build.rs
@@ -813,7 +813,7 @@ fn plonky2_trace_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir_path.to_str().unwrap());
-    cmd.arg("trace").arg("--trace-dir").arg(temp_dir.path());
+    cmd.arg("trace").arg("--out-dir").arg(temp_dir.path());
 
     let trace_dir_path = temp_dir.path().as_os_str().to_str().unwrap();
     let trace_file_path = temp_dir.path().join("trace.json");
@@ -896,7 +896,7 @@ fn plonky2_trace_plonky2_{test_name}() {{
 
     let mut cmd = Command::cargo_bin("nargo").unwrap();
     cmd.arg("--program-dir").arg(test_program_dir_path.to_str().unwrap());
-    cmd.arg("trace").arg("--trace-dir").arg(temp_dir.path()).arg("--trace-plonky2");
+    cmd.arg("trace").arg("--out-dir").arg(temp_dir.path()).arg("--trace-plonky2");
 
     let trace_dir_path = temp_dir.path().as_os_str().to_str().unwrap();
     let trace_file_path = temp_dir.path().join("trace.json");

--- a/tooling/nargo_cli/src/cli/trace_cmd.rs
+++ b/tooling/nargo_cli/src/cli/trace_cmd.rs
@@ -39,7 +39,7 @@ pub(crate) struct TraceCommand {
 
     /// Directory where to store trace.json
     #[clap(long, short)]
-    trace_dir: String,
+    out_dir: String,
 
     /// Insert plonky2 information to the trace file
     #[arg(long)]
@@ -146,7 +146,7 @@ pub(crate) fn run(args: TraceCommand, config: NargoConfig) -> Result<(), CliErro
         compiled_program,
         package,
         &args.prover_name,
-        &args.trace_dir,
+        &args.out_dir,
         debug_trace_list,
         args.compile_options.pedantic_solving,
     )
@@ -156,7 +156,7 @@ fn trace_program_and_decode(
     program: CompiledProgram,
     package: &Package,
     prover_name: &str,
-    trace_dir: &str,
+    out_dir: &str,
     debug_trace_list: Option<DebugTraceList>,
     pedantic_solving: bool,
 ) -> Result<(), CliError> {
@@ -168,7 +168,7 @@ fn trace_program_and_decode(
         &program,
         &package.name,
         &inputs_map,
-        trace_dir,
+        out_dir,
         debug_trace_list,
         pedantic_solving,
     )
@@ -178,7 +178,7 @@ pub(crate) fn trace_program(
     compiled_program: &CompiledProgram,
     crate_name: &CrateName,
     inputs_map: &InputMap,
-    trace_dir: &str,
+    out_dir: &str,
     debug_trace_list: Option<DebugTraceList>,
     pedantic_solving: bool,
 ) -> Result<(), CliError> {
@@ -205,7 +205,7 @@ pub(crate) fn trace_program(
         Ok(()) => (),
     };
 
-    store_trace(tracer, trace_dir);
+    store_trace(tracer, out_dir);
 
     Ok(())
 }

--- a/tooling/tracer/README.md
+++ b/tooling/tracer/README.md
@@ -2,4 +2,4 @@
 
 A tracer for Noir that produces execution traces.
 
-Invoke with `nargo trace --trace-dir=<place to store trace>`.
+Invoke with `nargo trace --out-dir=<place to store trace>`.

--- a/tooling/tracer/src/tracer_glue.rs
+++ b/tooling/tracer/src/tracer_glue.rs
@@ -12,8 +12,8 @@ use tracing::warn;
 
 /// Stores the trace accumulated in `tracer` in the specified directory. The trace is stored as
 /// multiple JSON files.
-pub fn store_trace(tracer: Tracer, trace_dir: &str) {
-    let trace_path = Path::new(trace_dir).join("trace.json");
+pub fn store_trace(tracer: Tracer, out_dir: &str) {
+    let trace_path = Path::new(out_dir).join("trace.json");
     let mut storing_errors = false;
     match tracer.store_trace_events(&trace_path) {
         Ok(_) => {}
@@ -23,7 +23,7 @@ pub fn store_trace(tracer: Tracer, trace_dir: &str) {
         }
     }
 
-    let trace_path = Path::new(trace_dir).join("trace_metadata.json");
+    let trace_path = Path::new(out_dir).join("trace_metadata.json");
     match tracer.store_trace_metadata(&trace_path) {
         Ok(_) => {}
         Err(err) => {
@@ -32,7 +32,7 @@ pub fn store_trace(tracer: Tracer, trace_dir: &str) {
         }
     }
 
-    let trace_path = Path::new(trace_dir).join("trace_paths.json");
+    let trace_path = Path::new(out_dir).join("trace_paths.json");
     match tracer.store_trace_paths(&trace_path) {
         Ok(_) => {}
         Err(err) => {
@@ -41,7 +41,7 @@ pub fn store_trace(tracer: Tracer, trace_dir: &str) {
         }
     }
     if !storing_errors {
-        println!("Saved trace to {}", trace_dir);
+        println!("Saved trace to {}", out_dir);
     }
 }
 


### PR DESCRIPTION
## Summary

- Rename nargo trace CLI flag from `--trace-dir` to `--out-dir` to match all other CodeTracer recorders (Python, Ruby, JS, WASM)
- Updates: `trace_cmd.rs` (clap field), `build.rs` (test invocations), `tracer_glue.rs` (parameter name), `README.md` (usage example)

Cross-repo: companion to metacraft-labs/codetracer#fix/harmonize-out-dir-flags

## Test plan

- [ ] `nargo trace --out-dir <dir>` works correctly
- [x] CodeTracer integration tests pass with updated flag name

🤖 Generated with [Claude Code](https://claude.com/claude-code)